### PR TITLE
Update extract-parts to use wast2json.

### DIFF
--- a/extract-parts.sh
+++ b/extract-parts.sh
@@ -10,17 +10,17 @@ set -o pipefail
 #  - malformed - wasm text tests that fail to parse
 
 wabt="../wabt"
-wabtbin="$wabt/out"
+wabtbin="$wabt/bin"
 
 mkdir -p valid invalid malformed
 rm -f valid/*.wasm
 rm -f invalid/*.wasm
 rm -f malformed/*.wat
 
-for wat in *.wat; do
-    base="${wat##*/}"
-    json="invalid/${base%.wat}.json"
-    "$wabtbin/wat2wasm" --spec "$wat" -o "$json"
+for wast in *.wast; do
+    base="${wast##*/}"
+    json="invalid/${base%.wast}.json"
+    "$wabtbin/wast2json" "$wast" -o "$json"
     rm "$json"
 done
 


### PR DESCRIPTION
Looks like wat2wasm was split into two commands and we need to use wast2json in the extract-parts.sh script.