### PR TITLE
mutable-global is now merged into the main spec repo.

### DIFF
--- a/update-testsuite.sh
+++ b/update-testsuite.sh
@@ -3,7 +3,7 @@ set -e
 set -u
 set -o pipefail
 
-repos='spec threads simd exception-handling gc bulk-memory-operations tail-call nontrapping-float-to-int-conversions multi-value host-bindings sign-extension-ops mutable-global reference-types'
+repos='spec threads simd exception-handling gc bulk-memory-operations tail-call nontrapping-float-to-int-conversions multi-value host-bindings sign-extension-ops reference-types'
 
 log_and_run() {
     echo ">>" $*


### PR DESCRIPTION
Remove mutable-global from the repos list, as it's now merged into the
spec repo.