### PR TITLE
Fix expected validation errors for `elem.drop`

### DIFF
--- a/proposals/bulk-memory-operations/table_init.wast
+++ b/proposals/bulk-memory-operations/table_init.wast
@@ -193,7 +193,7 @@
   (module
     (func (export "test")
       (elem.drop 0)))
-  "unknown table 0")
+  "unknown element segment 0")
 
 (assert_invalid
   (module
@@ -207,7 +207,7 @@
     (func (result i32) (i32.const 0))
     (func (export "test")
       (elem.drop 4)))
-  "unknown table 0")
+  "unknown element segment 4")
 
 (assert_invalid
   (module


### PR DESCRIPTION
The validation for `elem.drop` only checks that the referenced segment is valid within the context, it does not check the existence of tables. Therefore, when asserting that a module is invalid because of a bad segment index in `elem.drop`, we should expect an error message that references an unknown element segment, not a message that references an unknown table.

@binji care to take a look at this? thanks!