### PR TITLE
Add more documentation to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 This repository holds a mirror of the WebAssembly core testsuite which is maintained
-[here](https://github.com/WebAssembly/spec/tree/master/test/core).
+[here](https://github.com/WebAssembly/spec/tree/master/test/core), as well as the
+tests from the various
+[proposals repositories](https://github.com/WebAssembly/proposals/blob/master/README.md).
+
+To add new tests or report problems in existing tests, please file issues and PRs
+within the spec or individual proposal repositories rather than within this mirror
+repository.


### PR DESCRIPTION
Mention that this is mirroring the proposals repos too, and that issues
and PRs concerning the tests themselves should be sent upstream rather
than to this repo.