### PR TITLE
Fix some non-canonical NaNs in SIMD testsuite

### DIFF
--- a/proposals/simd/simd_f64x2.wast
+++ b/proposals/simd/simd_f64x2.wast
@@ -109,7 +109,7 @@
     (v128.const f64x2 nan 0)
     (v128.const f64x2 0 1)
   )
-  (v128.const f64x2 nan 0)
+  (v128.const f64x2 nan:canonical 0)
 )
 ;; f64x2.min
 (assert_return
@@ -117,7 +117,7 @@
     (v128.const f64x2 0 1)
     (v128.const f64x2 -nan 0)
   )
-  (v128.const f64x2 -nan 0)
+  (v128.const f64x2 nan:canonical 0)
 )
 ;; f64x2.min
 (assert_return

--- a/proposals/simd/simd_f64x2_arith.wast
+++ b/proposals/simd/simd_f64x2_arith.wast
@@ -5296,7 +5296,7 @@
 (assert_return (invoke "f64x2_mul_mixed") (v128.const f64x2 nan:arithmetic nan:canonical))
 (assert_return (invoke "f64x2_neg_canon") (v128.const f64x2 nan:canonical -1.0))
 (assert_return (invoke "f64x2_sqrt_canon") (v128.const f64x2 2.0 nan:canonical))
-(assert_return (invoke "f64x2_sub_arith") (v128.const f64x2 nan -2.0))
+(assert_return (invoke "f64x2_sub_arith") (v128.const f64x2 nan:canonical -2.0))
 
 ;; type check
 (assert_invalid (module (func (result v128) (f64x2.neg (i64.const 0)))) "type mismatch")


### PR DESCRIPTION
See https://github.com/WebAssembly/simd/pull/239.