### PR TITLE
Update for design's master -> main rename.

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -3,6 +3,6 @@
 Interested in participating? Please follow
 [the same contributing guidelines as the design repository][].
 
-  [the same contributing guidelines as the design repository]: https://github.com/WebAssembly/design/blob/master/Contributing.md
+  [the same contributing guidelines as the design repository]: https://github.com/WebAssembly/design/blob/main/Contributing.md
 
 Also, please be sure to read [the README.md](README.md) for this repository.


### PR DESCRIPTION
Also as a general heads-up, this testsuite repository's default branch
has also been renamed from `master` to `main`.