### PR TITLE
Rename "master" to "main" in spec repository URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Amalgamated WebAssembly Test Suite
 ==================================
 
 This repository holds a mirror of the WebAssembly core testsuite which is
-maintained [here](https://github.com/WebAssembly/spec/tree/master/test/core),
+maintained [here](https://github.com/WebAssembly/spec/tree/main/test/core),
 as well as the tests from the various [proposals
 repositories](https://github.com/WebAssembly/proposals/blob/master/README.md).
 

--- a/update-testsuite.sh
+++ b/update-testsuite.sh
@@ -77,9 +77,9 @@ merge_with_spec() {
         fi
         log_and_run git checkout try-merge
 
-        # Attempt to merge with spec/master.
+        # Attempt to merge with spec/main.
         log_and_run git reset origin/${branch} --hard
-        try_log_and_run git merge -q spec/master -m "merged"
+        try_log_and_run git merge -q spec/main -m "merged"
         if [ $? -ne 0 ]; then
             # Ignore merge conflicts in non-test directories.
             # We don't care about those changes.


### PR DESCRIPTION
The spec repository [now defaults to `main`], so rename URLs to it from
"master" to "main".

[now defaults to `main`]: https://github.com/WebAssembly/spec/issues/1368