### PR TITLE
Remove simd from update-testsuite.sh

### DIFF
--- a/update-testsuite.sh
+++ b/update-testsuite.sh
@@ -9,7 +9,6 @@ non_tests=":(exclude)test/"
 repos='
   spec
   threads
-  simd
   exception-handling
   gc
   tail-call
@@ -108,8 +107,7 @@ for repo in ${repos}; do
     if [ "${repo}" = "gc" -o \
          "${repo}" = "tail-call" -o \
          "${repo}" = "annotations" -o \
-         "${repo}" = "function-references" -o \
-         "${repo}" = "multi-memory" ]; then
+         "${repo}" = "function-references" ]; then
       branch=master
     else
       branch=main


### PR DESCRIPTION
The simd how now been merged into the spec.  This change
removed it from the update script.  The actuall tests
remain and I will remove them in a followup.

Also, update branch name multi-memory (looks like they
switch to main).