### PR TITLE
fix expected trap message in `bulk.wast`

### DIFF
--- a/bulk.wast
+++ b/bulk.wast
@@ -219,7 +219,7 @@
 (assert_trap (invoke "init" (i32.const 2) (i32.const 0) (i32.const 2))
     "out of bounds table access")
 (assert_trap (invoke "call" (i32.const 2))
-    "uninitialized element 2")
+    "uninitialized element")
 
 (invoke "init" (i32.const 0) (i32.const 1) (i32.const 2))
 (assert_return (invoke "call" (i32.const 0)) (i32.const 1))


### PR DESCRIPTION
Found this while implementing `reference-types` for the `wasmi` interpreter. While I like having more information at hand this trap message expectation is not uniform across the testsuite (just look a few lines behind the changed line) and therefore I thought this was an oversight.