### PR TITLE
Update repos + include legacy test files

### DIFF
--- a/proposals/exception-handling/legacy/rethrow.wast
+++ b/proposals/exception-handling/legacy/rethrow.wast
@@ -1,0 +1,96 @@
+;; Test rethrow instruction.
+
+(module
+  (tag $e0)
+  (tag $e1)
+
+  (func (export "catch-rethrow-0")
+    (try
+      (do (throw $e0))
+      (catch $e0 (rethrow 0))
+    )
+  )
+
+  (func (export "catch-rethrow-1") (param i32) (result i32)
+    (try (result i32)
+      (do (throw $e0))
+      (catch $e0
+        (if (i32.eqz (local.get 0)) (then (rethrow 1))) (i32.const 23)
+      )
+    )
+  )
+
+  (func (export "catchall-rethrow-0")
+    (try
+      (do (throw $e0))
+      (catch_all (rethrow 0))
+    )
+  )
+
+  (func (export "catchall-rethrow-1") (param i32) (result i32)
+    (try (result i32)
+      (do (throw $e0))
+      (catch_all
+        (if (i32.eqz (local.get 0)) (then (rethrow 1))) (i32.const 23)
+      )
+    )
+  )
+
+  (func (export "rethrow-nested") (param i32) (result i32)
+    (try (result i32)
+      (do (throw $e1))
+      (catch $e1
+        (try (result i32)
+          (do (throw $e0))
+          (catch $e0
+            (if (i32.eq (local.get 0) (i32.const 0)) (then (rethrow 1)))
+            (if (i32.eq (local.get 0) (i32.const 1)) (then (rethrow 2)))
+            (i32.const 23)
+          )
+        )
+      )
+    )
+  )
+
+  (func (export "rethrow-recatch") (param i32) (result i32)
+    (try (result i32)
+      (do (throw $e0))
+      (catch $e0
+        (try (result i32)
+         (do (if (i32.eqz (local.get 0)) (then (rethrow 2))) (i32.const 42))
+         (catch $e0 (i32.const 23))
+        )
+      )
+    )
+  )
+
+  (func (export "rethrow-stack-polymorphism")
+    (try
+      (do (throw $e0))
+      (catch $e0 (i32.const 1) (rethrow 0))
+    )
+  )
+)
+
+(assert_exception (invoke "catch-rethrow-0"))
+
+(assert_exception (invoke "catch-rethrow-1" (i32.const 0)))
+(assert_return (invoke "catch-rethrow-1" (i32.const 1)) (i32.const 23))
+
+(assert_exception (invoke "catchall-rethrow-0"))
+
+(assert_exception (invoke "catchall-rethrow-1" (i32.const 0)))
+(assert_return (invoke "catchall-rethrow-1" (i32.const 1)) (i32.const 23))
+(assert_exception (invoke "rethrow-nested" (i32.const 0)))
+(assert_exception (invoke "rethrow-nested" (i32.const 1)))
+(assert_return (invoke "rethrow-nested" (i32.const 2)) (i32.const 23))
+
+(assert_return (invoke "rethrow-recatch" (i32.const 0)) (i32.const 23))
+(assert_return (invoke "rethrow-recatch" (i32.const 1)) (i32.const 42))
+
+(assert_exception (invoke "rethrow-stack-polymorphism"))
+
+(assert_invalid (module (func (rethrow 0))) "invalid rethrow label")
+(assert_invalid (module (func (block (rethrow 0)))) "invalid rethrow label")
+(assert_invalid (module (func (try (do (rethrow 0)) (delegate 0))))
+                "invalid rethrow label")

--- a/proposals/exception-handling/legacy/throw.wast
+++ b/proposals/exception-handling/legacy/throw.wast
@@ -1,0 +1,51 @@
+;; Test throw instruction.
+
+(module
+  (tag $e0)
+  (tag $e-i32 (param i32))
+  (tag $e-f32 (param f32))
+  (tag $e-i64 (param i64))
+  (tag $e-f64 (param f64))
+  (tag $e-i32-i32 (param i32 i32))
+
+  (func $throw-if (export "throw-if") (param i32) (result i32)
+    (local.get 0)
+    (i32.const 0) (if (i32.ne) (then (throw $e0)))
+    (i32.const 0)
+  )
+
+  (func (export "throw-param-f32") (param f32) (local.get 0) (throw $e-f32))
+
+  (func (export "throw-param-i64") (param i64) (local.get 0) (throw $e-i64))
+
+  (func (export "throw-param-f64") (param f64) (local.get 0) (throw $e-f64))
+
+  (func $throw-1-2 (i32.const 1) (i32.const 2) (throw $e-i32-i32))
+  (func (export "test-throw-1-2")
+    (try
+      (do (call $throw-1-2))
+      (catch $e-i32-i32
+        (i32.const 2)
+        (if (i32.ne) (then (unreachable)))
+        (i32.const 1)
+        (if (i32.ne) (then (unreachable)))
+      )
+    )
+  )
+)
+
+(assert_return (invoke "throw-if" (i32.const 0)) (i32.const 0))
+(assert_exception (invoke "throw-if" (i32.const 10)))
+(assert_exception (invoke "throw-if" (i32.const -1)))
+
+(assert_exception (invoke "throw-param-f32" (f32.const 5.0)))
+(assert_exception (invoke "throw-param-i64" (i64.const 5)))
+(assert_exception (invoke "throw-param-f64" (f64.const 5.0)))
+
+(assert_return (invoke "test-throw-1-2"))
+
+(assert_invalid (module (func (throw 0))) "unknown tag 0")
+(assert_invalid (module (tag (param i32)) (func (throw 0)))
+                "type mismatch: instruction requires [i32] but stack has []")
+(assert_invalid (module (tag (param i32)) (func (i64.const 5) (throw 0)))
+                "type mismatch: instruction requires [i32] but stack has [i64]")

--- a/proposals/exception-handling/legacy/try_catch.wast
+++ b/proposals/exception-handling/legacy/try_catch.wast
@@ -1,0 +1,265 @@
+;; Test try-catch blocks.
+
+(module
+  (tag $e0 (export "e0"))
+  (func (export "throw") (throw $e0))
+)
+
+(register "test")
+
+(module
+  (tag $imported-e0 (import "test" "e0"))
+  (func $imported-throw (import "test" "throw"))
+  (tag $e0)
+  (tag $e1)
+  (tag $e2)
+  (tag $e-i32 (param i32))
+  (tag $e-f32 (param f32))
+  (tag $e-i64 (param i64))
+  (tag $e-f64 (param f64))
+
+  (func $throw-if (param i32) (result i32)
+    (local.get 0)
+    (i32.const 0) (if (i32.ne) (then (throw $e0)))
+    (i32.const 0)
+  )
+
+  (func (export "empty-catch") (try (do) (catch $e0)))
+
+  (func (export "simple-throw-catch") (param i32) (result i32)
+    (try (result i32)
+      (do (local.get 0) (i32.eqz) (if (then (throw $e0)) (else)) (i32.const 42))
+      (catch $e0 (i32.const 23))
+    )
+  )
+
+  (func (export "unreachable-not-caught") (try (do (unreachable)) (catch_all)))
+
+  (func $div (param i32 i32) (result i32)
+    (local.get 0) (local.get 1) (i32.div_u)
+  )
+  (func (export "trap-in-callee") (param i32 i32) (result i32)
+    (try (result i32)
+      (do (local.get 0) (local.get 1) (call $div))
+      (catch_all (i32.const 11))
+    )
+  )
+
+  (func (export "catch-complex-1") (param i32) (result i32)
+    (try (result i32)
+      (do
+        (try (result i32)
+          (do
+            (local.get 0)
+            (i32.eqz)
+            (if
+              (then (throw $e0))
+              (else
+                (local.get 0)
+                (i32.const 1)
+                (i32.eq)
+                (if (then (throw $e1)) (else (throw $e2)))
+              )
+            )
+            (i32.const 2)
+          )
+          (catch $e0 (i32.const 3))
+        )
+      )
+      (catch $e1 (i32.const 4))
+    )
+  )
+
+  (func (export "catch-complex-2") (param i32) (result i32)
+    (try (result i32)
+      (do
+        (local.get 0)
+        (i32.eqz)
+        (if
+          (then (throw $e0))
+          (else
+            (local.get 0)
+            (i32.const 1)
+            (i32.eq)
+            (if (then (throw $e1)) (else (throw $e2)))
+          )
+        )
+        (i32.const 2)
+      )
+      (catch $e0 (i32.const 3))
+      (catch $e1 (i32.const 4))
+    )
+  )
+
+  (func (export "throw-catch-param-i32") (param i32) (result i32)
+    (try (result i32)
+      (do (local.get 0) (throw $e-i32) (i32.const 2))
+      (catch $e-i32 (return))
+    )
+  )
+
+  (func (export "throw-catch-param-f32") (param f32) (result f32)
+    (try (result f32)
+      (do (local.get 0) (throw $e-f32) (f32.const 0))
+      (catch $e-f32 (return))
+    )
+  )
+
+  (func (export "throw-catch-param-i64") (param i64) (result i64)
+    (try (result i64)
+      (do (local.get 0) (throw $e-i64) (i64.const 2))
+      (catch $e-i64 (return))
+    )
+  )
+
+  (func (export "throw-catch-param-f64") (param f64) (result f64)
+    (try (result f64)
+      (do (local.get 0) (throw $e-f64) (f64.const 0))
+      (catch $e-f64 (return))
+    )
+  )
+
+  (func $throw-param-i32 (param i32) (local.get 0) (throw $e-i32))
+  (func (export "catch-param-i32") (param i32) (result i32)
+    (try (result i32)
+      (do (i32.const 0) (local.get 0) (call $throw-param-i32))
+      (catch $e-i32)
+    )
+  )
+
+  (func (export "catch-imported") (result i32)
+    (try (result i32)
+      (do
+        (i32.const 1)
+        (call $imported-throw)
+      )
+      (catch $imported-e0 (i32.const 2))
+    )
+  )
+
+  (func (export "catchless-try") (param i32) (result i32)
+    (try (result i32)
+      (do
+        (try (result i32)
+          (do (local.get 0) (call $throw-if))
+        )
+      )
+      (catch $e0 (i32.const 1))
+    )
+  )
+
+  (func $throw-void (throw $e0))
+  (func (export "return-call-in-try-catch")
+    (try
+      (do
+        (return_call $throw-void)
+      )
+      (catch $e0)
+    )
+  )
+
+  (table funcref (elem $throw-void))
+  (func (export "return-call-indirect-in-try-catch")
+    (try
+      (do
+        (return_call_indirect (param) (i32.const 0))
+      )
+      (catch $e0)
+    )
+  )
+)
+
+(assert_return (invoke "empty-catch"))
+
+(assert_return (invoke "simple-throw-catch" (i32.const 0)) (i32.const 23))
+(assert_return (invoke "simple-throw-catch" (i32.const 1)) (i32.const 42))
+
+(assert_trap (invoke "unreachable-not-caught") "unreachable")
+
+(assert_return (invoke "trap-in-callee" (i32.const 7) (i32.const 2)) (i32.const 3))
+(assert_trap (invoke "trap-in-callee" (i32.const 1) (i32.const 0)) "integer divide by zero")
+
+(assert_return (invoke "catch-complex-1" (i32.const 0)) (i32.const 3))
+(assert_return (invoke "catch-complex-1" (i32.const 1)) (i32.const 4))
+(assert_exception (invoke "catch-complex-1" (i32.const 2)))
+
+(assert_return (invoke "catch-complex-2" (i32.const 0)) (i32.const 3))
+(assert_return (invoke "catch-complex-2" (i32.const 1)) (i32.const 4))
+(assert_exception (invoke "catch-complex-2" (i32.const 2)))
+
+(assert_return (invoke "throw-catch-param-i32" (i32.const 0)) (i32.const 0))
+(assert_return (invoke "throw-catch-param-i32" (i32.const 1)) (i32.const 1))
+(assert_return (invoke "throw-catch-param-i32" (i32.const 10)) (i32.const 10))
+
+(assert_return (invoke "throw-catch-param-f32" (f32.const 5.0)) (f32.const 5.0))
+(assert_return (invoke "throw-catch-param-f32" (f32.const 10.5)) (f32.const 10.5))
+
+(assert_return (invoke "throw-catch-param-i64" (i64.const 5)) (i64.const 5))
+(assert_return (invoke "throw-catch-param-i64" (i64.const 0)) (i64.const 0))
+(assert_return (invoke "throw-catch-param-i64" (i64.const -1)) (i64.const -1))
+
+(assert_return (invoke "throw-catch-param-f64" (f64.const 5.0)) (f64.const 5.0))
+(assert_return (invoke "throw-catch-param-f64" (f64.const 10.5)) (f64.const 10.5))
+
+(assert_return (invoke "catch-param-i32" (i32.const 5)) (i32.const 5))
+
+(assert_return (invoke "catch-imported") (i32.const 2))
+
+(assert_return (invoke "catchless-try" (i32.const 0)) (i32.const 0))
+(assert_return (invoke "catchless-try" (i32.const 1)) (i32.const 1))
+
+(assert_exception (invoke "return-call-in-try-catch"))
+(assert_exception (invoke "return-call-indirect-in-try-catch"))
+
+(module
+  (func $imported-throw (import "test" "throw"))
+  (tag $e0)
+
+  (func (export "imported-mismatch") (result i32)
+    (try (result i32)
+      (do
+        (try (result i32)
+          (do
+            (i32.const 1)
+            (call $imported-throw)
+          )
+          (catch $e0 (i32.const 2))
+        )
+      )
+      (catch_all (i32.const 3))
+    )
+  )
+)
+
+(assert_return (invoke "imported-mismatch") (i32.const 3))
+
+(assert_malformed
+  (module quote "(module (func (catch_all)))")
+  "unexpected token"
+)
+
+(assert_malformed
+  (module quote "(module (tag $e) (func (catch $e)))")
+  "unexpected token"
+)
+
+(assert_malformed
+  (module quote
+    "(module (func (try (do) (catch_all) (catch_all))))"
+  )
+  "unexpected token"
+)
+
+(assert_invalid (module (func (result i32) (try (result i32) (do))))
+                "type mismatch: instruction requires [i32] but stack has []")
+(assert_invalid (module (func (result i32) (try (result i32) (do (i64.const 42)))))
+                "type mismatch: instruction requires [i32] but stack has [i64]")
+(assert_invalid (module (tag) (func (try (do) (catch 0 (i32.const 42)))))
+                "type mismatch: block requires [] but stack has [i32]")
+(assert_invalid (module
+                  (tag (param i64))
+                  (func (result i32)
+                    (try (result i32) (do (i32.const 42)) (catch 0))))
+                "type mismatch: instruction requires [i32] but stack has [i64]")
+(assert_invalid (module (func (try (do) (catch_all (i32.const 42)))))
+                "type mismatch: block requires [] but stack has [i32]")

--- a/proposals/exception-handling/legacy/try_delegate.wast
+++ b/proposals/exception-handling/legacy/try_delegate.wast
@@ -1,0 +1,199 @@
+;; Test try-delegate blocks.
+
+(module
+  (tag $e0)
+  (tag $e1)
+
+  (func (export "delegate-no-throw") (result i32)
+    (try $t (result i32)
+      (do (try (result i32) (do (i32.const 1)) (delegate $t)))
+      (catch $e0 (i32.const 2))
+    )
+  )
+
+  (func $throw-if (param i32)
+    (local.get 0)
+    (if (then (throw $e0)) (else))
+  )
+
+  (func (export "delegate-throw") (param i32) (result i32)
+    (try $t (result i32)
+      (do
+        (try (result i32)
+          (do (local.get 0) (call $throw-if) (i32.const 1))
+          (delegate $t)
+        )
+      )
+      (catch $e0 (i32.const 2))
+    )
+  )
+
+  (func (export "delegate-skip") (result i32)
+    (try $t (result i32)
+      (do
+        (try (result i32)
+          (do
+            (try (result i32)
+              (do (throw $e0) (i32.const 1))
+              (delegate $t)
+            )
+          )
+          (catch $e0 (i32.const 2))
+        )
+      )
+      (catch $e0 (i32.const 3))
+    )
+  )
+
+  (func (export "delegate-to-block") (result i32)
+    (try (result i32)
+      (do (block (try (do (throw $e0)) (delegate 0)))
+          (i32.const 0))
+      (catch_all (i32.const 1)))
+  )
+
+  (func (export "delegate-to-catch") (result i32)
+    (try (result i32)
+      (do (try
+            (do (throw $e0))
+            (catch $e0
+              (try (do (rethrow 1)) (delegate 0))))
+          (i32.const 0))
+      (catch_all (i32.const 1)))
+  )
+
+  (func (export "delegate-to-caller-trivial")
+    (try
+      (do (throw $e0))
+      (delegate 0)))
+
+  (func (export "delegate-to-caller-skipping")
+    (try (do (try (do (throw $e0)) (delegate 1))) (catch_all))
+  )
+
+  (func $select-tag (param i32)
+    (block (block (block (local.get 0) (br_table 0 1 2)) (return)) (throw $e0))
+    (throw $e1)
+  )
+
+  (func (export "delegate-merge") (param i32 i32) (result i32)
+    (try $t (result i32)
+      (do
+        (local.get 0)
+        (call $select-tag)
+        (try
+          (result i32)
+          (do (local.get 1) (call $select-tag) (i32.const 1))
+          (delegate $t)
+        )
+      )
+      (catch $e0 (i32.const 2))
+    )
+  )
+
+  (func (export "delegate-throw-no-catch") (result i32)
+    (try (result i32)
+      (do (try (result i32) (do (throw $e0) (i32.const 1)) (delegate 0)))
+      (catch $e1 (i32.const 2))
+    )
+  )
+
+  (func (export "delegate-correct-targets") (result i32)
+    (try (result i32)
+      (do (try $l3
+            (do (try $l2
+                  (do (try $l1
+                        (do (try $l0
+                              (do (try
+                                    (do (throw $e0))
+                                    (delegate $l1)))
+                              (catch_all unreachable)))
+                        (delegate $l3)))
+                  (catch_all unreachable)))
+            (catch_all (try
+                         (do (throw $e0))
+                         (delegate $l3))))
+          unreachable)
+      (catch_all (i32.const 1))))
+
+  (func $throw-void (throw $e0))
+  (func (export "return-call-in-try-delegate")
+    (try $l
+      (do
+        (try
+          (do
+            (return_call $throw-void)
+          )
+          (delegate $l)
+        )
+      )
+      (catch $e0)
+    )
+  )
+
+  (table funcref (elem $throw-void))
+  (func (export "return-call-indirect-in-try-delegate")
+    (try $l
+      (do
+        (try
+          (do
+            (return_call_indirect (param) (i32.const 0))
+          )
+          (delegate $l)
+        )
+      )
+      (catch $e0)
+    )
+  )
+)
+
+(assert_return (invoke "delegate-no-throw") (i32.const 1))
+
+(assert_return (invoke "delegate-throw" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "delegate-throw" (i32.const 1)) (i32.const 2))
+
+(assert_exception (invoke "delegate-throw-no-catch"))
+
+(assert_return (invoke "delegate-merge" (i32.const 1) (i32.const 0)) (i32.const 2))
+(assert_exception (invoke "delegate-merge" (i32.const 2) (i32.const 0)))
+(assert_return (invoke "delegate-merge" (i32.const 0) (i32.const 1)) (i32.const 2))
+(assert_exception (invoke "delegate-merge" (i32.const 0) (i32.const 2)))
+(assert_return (invoke "delegate-merge" (i32.const 0) (i32.const 0)) (i32.const 1))
+
+(assert_return (invoke "delegate-skip") (i32.const 3))
+
+(assert_return (invoke "delegate-to-block") (i32.const 1))
+(assert_return (invoke "delegate-to-catch") (i32.const 1))
+
+(assert_exception (invoke "delegate-to-caller-trivial"))
+(assert_exception (invoke "delegate-to-caller-skipping"))
+
+(assert_return (invoke "delegate-correct-targets") (i32.const 1))
+
+(assert_exception (invoke "return-call-in-try-delegate"))
+(assert_exception (invoke "return-call-indirect-in-try-delegate"))
+
+(assert_malformed
+  (module quote "(module (func (delegate 0)))")
+  "unexpected token"
+)
+
+(assert_malformed
+  (module quote "(module (tag $e) (func (try (do) (catch $e) (delegate 0))))")
+  "unexpected token"
+)
+
+(assert_malformed
+  (module quote "(module (func (try (do) (catch_all) (delegate 0))))")
+  "unexpected token"
+)
+
+(assert_malformed
+  (module quote "(module (func (try (do) (delegate) (delegate 0))))")
+  "unexpected token"
+)
+
+(assert_invalid
+  (module (func (try (do) (delegate 1))))
+  "unknown label"
+)

--- a/update-testsuite.sh
+++ b/update-testsuite.sh
@@ -123,7 +123,14 @@ for repo in ${repos}; do
             for new in $(find test/core -name \*.wast); do
                 old=../../repos/spec/${new}
                 if [[ ! -f ${old} ]] || ! diff ${old} ${new} >/dev/null; then
-                    log_and_run cp ${new} ../../${wast_dir}
+                    log_and_run cp ${new} ../../${wast_dir}/
+                fi
+            done
+            for new in $(find test/legacy -name \*.wast); do
+                old=../../repos/spec/${new}
+                if [[ ! -f ${old} ]] || ! diff ${old} ${new} >/dev/null; then
+                    mkdir -p ../../${wast_dir}/legacy/
+                    log_and_run cp ${new} ../../${wast_dir}/legacy/
                 fi
             done
         popdir


### PR DESCRIPTION
  spec:
    https://github.com/WebAssembly/spec/commit/22854975
  exception-handling:
    https://github.com/WebAssembly/exception-handling/commit/d399b9e0

The `update-testsuite.sh` will not include files under `legacy` as well as `core`.  This is so that the legacy exception handling tests are now included.

The test updates themselves were automatically generated by `update-testsuite.sh`