### PR TITLE
Track acquire-release-atomics in testsuite repos

### DIFF
--- a/update-testsuite.py
+++ b/update-testsuite.py
@@ -141,6 +141,7 @@ def main():
         Repo('custom-page-sizes'),
         Repo('wide-arithmetic'),
         Repo('custom-descriptors'),
+        Repo('acquire-release-atomics'),
     ]
 
     # Make sure that `repos` is a git repository


### PR DESCRIPTION
It fails to import at the moment because the `threads` repo (and acquire-release-atomics as a result) is far behind `spec`. Add it now so we have the tests once these are rebased.

 cc @rmahdav 